### PR TITLE
Fix uncontrolled flow of $digest() calls at upgrade module

### DIFF
--- a/packages/upgrade/src/static/upgrade_module.ts
+++ b/packages/upgrade/src/static/upgrade_module.ts
@@ -247,13 +247,12 @@ export class UpgradeModule {
                     $rootScope.$$phase ? $rootScope.$applyAsync() : $rootScope.$digest();
                   };
 
-                  // suppress continuous flow of digests calls during one frame interval and schedule single $digests() to next frame
                   const subscription = this.ngZone.onMicrotaskEmpty
                     .filter(() => !isDigestScheduled)
                     .subscribe(() => {
-                      // digest happened in previous frames - no problem, run digest again
+                      // digest happened in previous frame(s) - no problem, run digest again
                       if (window.performance.now() - lastRun > FRAME_DURATION) {
-                        digestsPerFrame = 0;
+                        digestsPerFrame = 1;
                         runDigest();
                       } else {
                         // detected attempt to run several digests in one frame - allow only two $digest() calls

--- a/packages/upgrade/src/static/upgrade_module.ts
+++ b/packages/upgrade/src/static/upgrade_module.ts
@@ -255,8 +255,8 @@ export class UpgradeModule {
                         digestsPerFrame = 1;
                         runDigest();
                       } else {
-                        // detected attempt to run several digests in one frame - allow only two $digest() calls
-                        // if more - skill all further calls and schedule single $digest() to next frame
+                        // detected attempt to run several digests in one frame - allow only two digests then
+                        // if more - skip all further attempts and schedule digest on next frame
                         if (digestsPerFrame < 2) {
                           digestsPerFrame++;
                           runDigest();


### PR DESCRIPTION
Allow no more than 2 `$digest()` calls per `16ms` interval for hybrid app.
If more attempts - schedule to run digest in next frame and skip any coming requests before that.